### PR TITLE
1.1.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,3 +52,5 @@ jobs:
               uses: andresz1/size-limit-action@v1.8.0
               with:
                 github_token: ${{ secrets.GITHUB_TOKEN }}
+                skip_step: install
+                directory: ./dist

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,3 +48,5 @@ jobs:
               run: pnpm run build
             - name: Build Stackblitz
               run:  pnpm dlx pkg-pr-new@0.0 publish --compact --pnpm .
+            - name: size-limit-action
+              uses: andresz1/size-limit-action@v1.8.0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,3 +50,5 @@ jobs:
               run:  pnpm dlx pkg-pr-new@0.0 publish --compact --pnpm .
             - name: size-limit-action
               uses: andresz1/size-limit-action@v1.8.0
+              with:
+                github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,8 +30,6 @@ jobs:
               uses: actions/checkout@v4
             - name: Install pnpm
               uses: pnpm/action-setup@v4
-              with:
-                version: 10
             - name: Use Node.js ${{ matrix.node-version }}
               uses: actions/setup-node@v4
               with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,10 +48,3 @@ jobs:
               run: pnpm run build
             - name: Build Stackblitz
               run:  pnpm dlx pkg-pr-new@0.0 publish --compact --pnpm .
-            - name: size-limit-action
-              uses: andresz1/size-limit-action@v1.8.0
-              with:
-                github_token: ${{ secrets.GITHUB_TOKEN }}
-                skip_step: install
-                directory: ./dist
-                package_manger: pnpm

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,3 +54,4 @@ jobs:
                 github_token: ${{ secrets.GITHUB_TOKEN }}
                 skip_step: install
                 directory: ./dist
+                package_manger: pnpm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,8 +33,6 @@ jobs:
               uses: actions/checkout@v4
             - name: Install pnpm
               uses: pnpm/action-setup@v4
-              with:
-                version: 10
             - name: Use Node.js ${{ matrix.node-version }}
               uses: actions/setup-node@v4
               with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # CHANGELOG
 
+## [1.1.0] 03-28-2025
+
+### Fixed
+
+- Duplicate root value could be added
+- Wrong childCount update when removing nodes
+- `branch` not detecting deeply invalid values
+- `branch` not stopping when target value has been reached in the middle of the branch.
+
+### Added
+
+- `addAll` to parse arrays into the tree
+- `nodeByValue` to extract a node by its value for sub-tree operations
+- Ability to search with primitive values in complex data in `has`, `branch`, `remove` and `nodeByValue`
+
 ## [1.0.1] 03-27-2025
 
 - Change: rename `micro-tree` to `mini-tree` due to npm registry bug: [issue](https://github.com/npm/cli/issues/8194)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # mini-tree
 
 <p align="center">
-<h1 align="center">The smallest data tree structure for any purpose</h1>
+<h1 align="center">The smallest tree data structure for any purpose</h1>
 <p align="center">
   <a href="https://www.npmjs.com/package/mini-tree"><img src="https://img.shields.io/npm/v/mini-tree?style=for-the-badge&logo=npm"/></a>
   <a href="https://npmtrends.com/mini-tree"><img src="https://img.shields.io/npm/dm/mini-tree?style=for-the-badge"/></a>
@@ -65,7 +65,7 @@ tree.add(9, (n, v) => n.value > v, (n, v) => n.value === 5)
 tree.add(13, comp, eq, tree.node(3))
 
 // Remove node with a specific value
-tree.remove((n) => n.value === 5)
+tree.remove(5)
 
 // Traverse through all nodes using BFS
 for (const node of tree) {
@@ -74,6 +74,47 @@ for (const node of tree) {
 
 // Find nodes
 if (tree.has(7)) // Do cool stuff
+```
+
+### Usage with complex data
+
+Normally, you won't just use trees for mere numbers, but rather to hierarchically order metadata of specific items, like menus with sub menus, folders with files or categories with objects. For that, it's much easier to search for nodes using primitive values as keys.
+
+```typescript
+interface PathMetaData {
+  path: string
+  isDir: boolean
+  fileCount: number
+}
+// ...
+
+// Define a tree where the key (the value to compare to) is the path.
+const comp: TreeComparator<PathMetaData, string> = (n, v) => v.startsWith(n.value.path)
+const eq: TreeComparator<PathMetaData, string> = (n, v) => v === n.value.path
+
+const tree = new Tree<PathMetaData, string>({ path: '/', isDir: true, fileCount: 7 }, comp, eq)
+
+// Since we are adding complex data, the key to search for, i.e. the path string, doesn't fit when trying to
+// order new elements to the tree. So we need to define custom comparators for simply adding new data.
+tree.addAll([
+  { path: '/package.json', dir: false, fileCount: 0 },
+  { path: '/a', dir: true, fileCount: 1 },
+  { path: '/a/package.json', dir: false, fileCount: 0 },
+  { path: '/a/b', dir: true, fileCount: 0 }
+], (n, v) => v.path.startsWith(n.value.path), (n, v) => v.path === n.value.path)
+
+// Find values
+tree.has('/')
+tree.has('/a/b')
+
+// Get the branch with the value of /a/b
+// This returns the actual complex data as an array
+tree.branch('/a/b')
+
+tree.remove('/package.json')
+
+// Find the node with the value '/a' and start searching from there.
+tree.has('/a/b', comp, eq, tree.nodeByValue('/a'))
 ```
 
 ---

--- a/index.d.ts
+++ b/index.d.ts
@@ -119,28 +119,28 @@ declare module 'mini-tree' {
      *  Extracts the values from a branch that matches the target value as close as possible.
      *
      *  @param targetValue - value to search for.
-     *  @param mapper - callback to decide whether to traverse downwards to the children.
+     *  @param comp - callback to decide whether to traverse downwards to the children.
      *  @param root - starting element to traverse through. By default, it starts at the tree root.
      *  @param store - array holding the values. New values will be pushed onto it. By default, a new array with
      *  the root element will be created.
      *  @returns the values of the branch leading towards the targeted value. If the value couldn't be found at all, it will return an empty array.
      */
-    branch(targetValue: T, traverser?: TreeComparator<T>, root?: TreeNode<T>, store?: T[]): T[]
+    branch(targetValue: T, comp?: TreeComparator<T>, root?: TreeNode<T>, store?: T[]): T[]
     /**
      *  Finds a node by its id. Ids are an internally incremened number.
      *
-     * @param id - internal id of the targeted node.
-     * @returns either the found node or `undefined`.
+     *  @param id - internal id of the targeted node.
+     *  @returns either the found node or `undefined`.
      */
     node(id: number): TreeNode<T> | undefined
     /**
      *  Checks if a specific value exists inside the tree.
      *
-     * @param value - target value.
-     * @param comp - comparator callback to compare the node value with the target value with.
-     * @param traverser - callback to decide whether to traverse downwards to the children.
-     * @param root - starting element to traverse through. By default, it starts at the tree root.
-     * @returns `true`, if the tree has the value, otherwise `false`.
+     *  @param value - target value.
+     *  @param comp - comparator callback to compare the node value with the target value with.
+     *  @param traverser - callback to decide whether to traverse downwards to the children.
+     *  @param root - starting element to traverse through. By default, it starts at the tree root.
+     *  @returns `true`, if the tree has the value, otherwise `false`.
      */
     has(value: T, comp?: TreeComparator<T>, traverser?: TreeComparator<T>, root?: TreeNode<T>): boolean
     [Symbol.iterator](): Iterator<TreeNode<T>>

--- a/index.d.ts
+++ b/index.d.ts
@@ -127,7 +127,7 @@ declare module 'mini-tree' {
      */
     branch(targetValue: T, comp?: TreeComparator<T>, root?: TreeNode<T>, store?: T[]): T[]
     /**
-     *  Finds a node by its id. Ids are an internally incremened number.
+     *  Finds a node by its id. Ids are an internally incremented number.
      *
      *  @param id - internal id of the targeted node.
      *  @returns either the found node or `undefined`.
@@ -137,7 +137,7 @@ declare module 'mini-tree' {
      *  Checks if a specific value exists inside the tree.
      *
      *  @param value - target value.
-     *  @param comp - comparator callback to compare the node value with the target value with.
+     *  @param comp - comparator callback to compare the node value with the target value with for further traversal.
      *  @param traverser - callback to decide whether to traverse downwards to the children.
      *  @param root - starting element to traverse through. By default, it starts at the tree root.
      *  @returns `true`, if the tree has the value, otherwise `false`.

--- a/index.d.ts
+++ b/index.d.ts
@@ -2,7 +2,7 @@ declare module 'mini-tree' {
   /**
    *  Callback type comparing a TreeNode to a specific value for checks.
    */
-  export type TreeComparator<T> = (root: TreeNode<T>, value: T) => boolean
+  export type TreeComparator<T, U = T> = (root: TreeNode<T>, value: U) => boolean
   /**
    *  Callback type validating a TreeNode for further traversal to its children.
    */
@@ -77,7 +77,7 @@ declare module 'mini-tree' {
   /**
    *  Generic tree structure for all sorts of purposes.
    */
-  export default class Tree<T> {
+  export default class Tree<T, U = T> {
     /**
      *  The number of nodes inside the tree.
      */
@@ -86,10 +86,10 @@ declare module 'mini-tree' {
      *  The root element of the tree.
      */
     root: TreeNode<T>
-    readonly #comp: TreeComparator<T>
-    readonly #eq: TreeComparator<T>
+    readonly #comp: TreeComparator<T, U>
+    readonly #eq: TreeComparator<T, U>
 
-    constructor(rootValue: T, comp: TreeComparator<T>, eq?: TreeComparator<T>)
+    constructor(rootValue: T, comp: TreeComparator<T, U>, eq?: TreeComparator<T, U>)
     /**
      *  Adds a new node to the tree.
      *
@@ -98,7 +98,16 @@ declare module 'mini-tree' {
      *  @param eq - callback checking if the target value is equal to a node value. If it's equal, it will cancel the process.
      *  @param root - starting element to traverse through. By default, it starts at the tree root.
      */
-    add(value: T, traverser?: TreeComparator<T>, eq?: TreeComparator<T>, root?: TreeNode<T>): void
+    add(value: T, traverser?: TreeComparator<T, T>, eq?: TreeComparator<T, T>, root?: TreeNode<T>): void
+    /**
+     *  Adds an array of new nodes to the tree.
+     *
+     *  @param values - array holding the target values to insert.
+     *  @param traverser - callback mapping the target value to a node value to check for further traversal.
+     *  @param eq - callback checking if the target value is equal to a node value. If it's equal, it will cancel the process.
+     *  @param root - starting element to traverse through. By default, it starts at the tree root.
+     */
+    addAll(values: T[], traverser: TreeComparator<T, T>, eq: TreeComparator<T, T>, root): void
     /**
      *  Traverses the tree with an asynchronous traverser with the added optimization of running all children parallel.
      *
@@ -114,7 +123,7 @@ declare module 'mini-tree' {
      *  @param traverser - callback to decide whether to traverse downwards to the children.
      *  @param root - starting element to traverse through. By default, it starts at the tree root.
      */
-    remove(value: T, comp?: TreeComparator<T>, traverser?: TreeComparator<T>, root?: TreeNode<T>): void
+    remove(value: U, comp?: TreeComparator<T, U>, traverser?: TreeComparator<T, U>, root?: TreeNode<T>): void
     /**
      *  Extracts the values from a branch that matches the target value as close as possible.
      *
@@ -125,7 +134,7 @@ declare module 'mini-tree' {
      *  the root element will be created.
      *  @returns the values of the branch leading towards the targeted value. If the value couldn't be found at all, it will return an empty array.
      */
-    branch(targetValue: T, comp?: TreeComparator<T>, root?: TreeNode<T>, store?: T[]): T[]
+    branch(targetValue: U, comp?: TreeComparator<T, U>, root?: TreeNode<T>, store?: T[]): T[]
     /**
      *  Finds a node by its id. Ids are an internally incremented number.
      *
@@ -133,6 +142,16 @@ declare module 'mini-tree' {
      *  @returns either the found node or `undefined`.
      */
     node(id: number): TreeNode<T> | undefined
+    /**
+     *  Finds a node by a given search value. It's particularly useful for getting an inner node to act as a sub-tree root for sub-tree operations.
+     *
+     *  @param value - target search value
+     *  @param comp - comparator callback to compare the node value with the target value with for further traversal.
+     *  @param eq - equality callback to compare the node value with the target to determine the correct node to find.
+     *  @param root - starting element to traverse through. By default, it starts at the tree root.
+     *  @returns either the desired `TreeNode` or `undefined`, if not found.
+     */
+    nodeByValue(value: U, comp: TreeComparator<T, U>, eq: TreeComparator<T, U>, root): TreeNode<T> | undefined
     /**
      *  Checks if a specific value exists inside the tree.
      *
@@ -142,7 +161,7 @@ declare module 'mini-tree' {
      *  @param root - starting element to traverse through. By default, it starts at the tree root.
      *  @returns `true`, if the tree has the value, otherwise `false`.
      */
-    has(value: T, comp?: TreeComparator<T>, traverser?: TreeComparator<T>, root?: TreeNode<T>): boolean
+    has(value: U, comp?: TreeComparator<T, U>, traverser?: TreeComparator<T, U>, root?: TreeNode<T>): boolean
     [Symbol.iterator](): Iterator<TreeNode<T>>
   }
 }

--- a/package.json
+++ b/package.json
@@ -47,8 +47,5 @@
     "jiti": "^2.4.2",
     "typescript": "^5.8.2",
     "vitest": "^3.0.9"
-  },
-  "dependencies": {
-    "@rollup/rollup-win32-ia32-msvc": "^4.37.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mini-tree",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "A tiny universal tree data structure that just works!",
   "types": "./index.d.ts",
   "main": "./dist/index.js",

--- a/package.json
+++ b/package.json
@@ -43,9 +43,12 @@
     "@vitest/coverage-v8": "^3.0.9",
     "esbuild": "^0.25.1",
     "eslint": "^9.23.0",
-    "jiti": "^2.4.2",
     "eslint-config-shiny": "^4.1.0",
+    "jiti": "^2.4.2",
     "typescript": "^5.8.2",
     "vitest": "^3.0.9"
+  },
+  "dependencies": {
+    "@rollup/rollup-win32-ia32-msvc": "^4.37.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,9 @@ importers:
 
   .:
     dependencies:
-      jiti:
-        specifier: ^2.4.2
-        version: 2.4.2
+      '@rollup/rollup-win32-ia32-msvc':
+        specifier: ^4.37.0
+        version: 4.37.0
     devDependencies:
       '@types/node':
         specifier: ^22.13.14
@@ -27,6 +27,9 @@ importers:
       eslint-config-shiny:
         specifier: ^4.1.0
         version: 4.1.0(@typescript-eslint/utils@8.28.0(eslint@9.23.0(jiti@2.4.2))(typescript@5.8.2))(@vue/compiler-sfc@3.5.13)(eslint-plugin-react@7.37.3(eslint@9.23.0(jiti@2.4.2)))(jiti@2.4.2)(picomatch@4.0.2)(ts-api-utils@2.1.0(typescript@5.8.2))(typescript@5.8.2)(vitest@3.0.9(@types/node@22.13.14)(jiti@2.4.2)(stylus@0.57.0))
+      jiti:
+        specifier: ^2.4.2
+        version: 2.4.2
       typescript:
         specifier: ^5.8.2
         version: 5.8.2
@@ -3193,8 +3196,7 @@ snapshots:
   '@rollup/rollup-win32-arm64-msvc@4.37.0':
     optional: true
 
-  '@rollup/rollup-win32-ia32-msvc@4.37.0':
-    optional: true
+  '@rollup/rollup-win32-ia32-msvc@4.37.0': {}
 
   '@rollup/rollup-win32-x64-msvc@4.37.0':
     optional: true
@@ -3239,13 +3241,13 @@ snapshots:
 
   '@types/normalize-package-data@2.4.4': {}
 
-  '@typescript-eslint/eslint-plugin@8.28.0(@typescript-eslint/parser@8.28.0(eslint@9.23.0(jiti@2.4.2))(typescript@5.8.2))(eslint@9.23.0(jiti@2.4.2))(typescript@5.8.2)':
+  '@typescript-eslint/eslint-plugin@8.28.0(@typescript-eslint/parser@8.28.0(eslint@9.18.0(jiti@2.4.2))(typescript@5.8.2))(eslint@9.23.0(jiti@2.4.2))(typescript@5.8.2)':
     dependencies:
       '@eslint-community/regexpp': 4.12.1
-      '@typescript-eslint/parser': 8.28.0(eslint@9.18.0(jiti@2.4.2))(typescript@5.8.2)
+      '@typescript-eslint/parser': 8.28.0(eslint@9.23.0(jiti@2.4.2))(typescript@5.8.2)
       '@typescript-eslint/scope-manager': 8.28.0
-      '@typescript-eslint/type-utils': 8.28.0(eslint@9.18.0(jiti@2.4.2))(typescript@5.8.2)
-      '@typescript-eslint/utils': 8.28.0(eslint@9.18.0(jiti@2.4.2))(typescript@5.8.2)
+      '@typescript-eslint/type-utils': 8.28.0(eslint@9.23.0(jiti@2.4.2))(typescript@5.8.2)
+      '@typescript-eslint/utils': 8.28.0(eslint@9.23.0(jiti@2.4.2))(typescript@5.8.2)
       '@typescript-eslint/visitor-keys': 8.28.0
       eslint: 9.23.0(jiti@2.4.2)
       graphemer: 1.4.0
@@ -3256,14 +3258,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.28.0(eslint@9.18.0(jiti@2.4.2))(typescript@5.8.2)':
+  '@typescript-eslint/parser@8.28.0(eslint@9.23.0(jiti@2.4.2))(typescript@5.8.2)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.28.0
       '@typescript-eslint/types': 8.28.0
       '@typescript-eslint/typescript-estree': 8.28.0(typescript@5.8.2)
       '@typescript-eslint/visitor-keys': 8.28.0
       debug: 4.4.0
-      eslint: 9.18.0(jiti@2.4.2)
+      eslint: 9.23.0(jiti@2.4.2)
       typescript: 5.8.2
     transitivePeerDependencies:
       - supports-color
@@ -3276,9 +3278,20 @@ snapshots:
   '@typescript-eslint/type-utils@8.28.0(eslint@9.18.0(jiti@2.4.2))(typescript@5.8.2)':
     dependencies:
       '@typescript-eslint/typescript-estree': 8.28.0(typescript@5.8.2)
-      '@typescript-eslint/utils': 8.28.0(eslint@9.18.0(jiti@2.4.2))(typescript@5.8.2)
+      '@typescript-eslint/utils': 8.28.0(eslint@9.23.0(jiti@2.4.2))(typescript@5.8.2)
       debug: 4.4.0
       eslint: 9.18.0(jiti@2.4.2)
+      ts-api-utils: 2.1.0(typescript@5.8.2)
+      typescript: 5.8.2
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/type-utils@8.28.0(eslint@9.23.0(jiti@2.4.2))(typescript@5.8.2)':
+    dependencies:
+      '@typescript-eslint/typescript-estree': 8.28.0(typescript@5.8.2)
+      '@typescript-eslint/utils': 8.28.0(eslint@9.23.0(jiti@2.4.2))(typescript@5.8.2)
+      debug: 4.4.0
+      eslint: 9.23.0(jiti@2.4.2)
       ts-api-utils: 2.1.0(typescript@5.8.2)
       typescript: 5.8.2
     transitivePeerDependencies:
@@ -3302,7 +3315,7 @@ snapshots:
 
   '@typescript-eslint/utils@8.28.0(eslint@9.18.0(jiti@2.4.2))(typescript@5.8.2)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.5.1(eslint@9.18.0(jiti@2.4.2))
+      '@eslint-community/eslint-utils': 4.5.1(eslint@9.23.0(jiti@2.4.2))
       '@typescript-eslint/scope-manager': 8.28.0
       '@typescript-eslint/types': 8.28.0
       '@typescript-eslint/typescript-estree': 8.28.0(typescript@5.8.2)
@@ -3313,7 +3326,7 @@ snapshots:
 
   '@typescript-eslint/utils@8.28.0(eslint@9.23.0(jiti@2.4.2))(typescript@5.8.2)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.5.1(eslint@9.18.0(jiti@2.4.2))
+      '@eslint-community/eslint-utils': 4.5.1(eslint@9.23.0(jiti@2.4.2))
       '@typescript-eslint/scope-manager': 8.28.0
       '@typescript-eslint/types': 8.28.0
       '@typescript-eslint/typescript-estree': 8.28.0(typescript@5.8.2)
@@ -3885,8 +3898,8 @@ snapshots:
       '@stylistic/eslint-plugin-js': 2.12.1(eslint@9.18.0(jiti@2.4.2))
       '@stylistic/eslint-plugin-jsx': 2.12.1(eslint@9.18.0(jiti@2.4.2))
       '@stylistic/eslint-plugin-ts': 2.12.1(eslint@9.18.0(jiti@2.4.2))(typescript@5.8.2)
-      '@typescript-eslint/eslint-plugin': 8.28.0(@typescript-eslint/parser@8.28.0(eslint@9.23.0(jiti@2.4.2))(typescript@5.8.2))(eslint@9.23.0(jiti@2.4.2))(typescript@5.8.2)
-      '@typescript-eslint/parser': 8.28.0(eslint@9.18.0(jiti@2.4.2))(typescript@5.8.2)
+      '@typescript-eslint/eslint-plugin': 8.28.0(@typescript-eslint/parser@8.28.0(eslint@9.18.0(jiti@2.4.2))(typescript@5.8.2))(eslint@9.23.0(jiti@2.4.2))(typescript@5.8.2)
+      '@typescript-eslint/parser': 8.28.0(eslint@9.23.0(jiti@2.4.2))(typescript@5.8.2)
       '@vitest/eslint-plugin': 1.1.25(@typescript-eslint/utils@8.28.0(eslint@9.23.0(jiti@2.4.2))(typescript@5.8.2))(eslint@9.18.0(jiti@2.4.2))(typescript@5.8.2)(vitest@3.0.9(@types/node@22.13.14)(jiti@2.4.2)(stylus@0.57.0))
       eslint: 9.18.0(jiti@2.4.2)
       eslint-import-resolver-custom-alias: 1.3.2(eslint-plugin-import@2.31.0)
@@ -3895,8 +3908,8 @@ snapshots:
       eslint-plugin-autofix: 2.2.0(eslint@9.18.0(jiti@2.4.2))
       eslint-plugin-compat: 6.0.2(eslint@9.18.0(jiti@2.4.2))
       eslint-plugin-es-x: 8.6.1(eslint@9.18.0(jiti@2.4.2))
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.28.0(eslint@9.23.0(jiti@2.4.2))(typescript@5.8.2))(eslint@9.23.0(jiti@2.4.2))
-      eslint-plugin-jest: 28.11.0(@typescript-eslint/eslint-plugin@8.28.0(@typescript-eslint/parser@8.28.0(eslint@9.23.0(jiti@2.4.2))(typescript@5.8.2))(eslint@9.18.0(jiti@2.4.2))(typescript@5.8.2))(eslint@9.18.0(jiti@2.4.2))(typescript@5.8.2)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.28.0(eslint@9.18.0(jiti@2.4.2))(typescript@5.8.2))(eslint@9.23.0(jiti@2.4.2))
+      eslint-plugin-jest: 28.11.0(@typescript-eslint/eslint-plugin@8.28.0(@typescript-eslint/parser@8.28.0(eslint@9.18.0(jiti@2.4.2))(typescript@5.8.2))(eslint@9.18.0(jiti@2.4.2))(typescript@5.8.2))(eslint@9.18.0(jiti@2.4.2))(typescript@5.8.2)
       eslint-plugin-jest-dom: 5.5.0(eslint@9.18.0(jiti@2.4.2))
       eslint-plugin-jest-formatting: 3.1.0(eslint@9.18.0(jiti@2.4.2))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.18.0(jiti@2.4.2))
@@ -3932,7 +3945,7 @@ snapshots:
       ora: 8.1.1
       semver: 7.6.3
       strip-json-comments: 5.0.1
-      vue-eslint-parser: 9.4.3(eslint@9.18.0(jiti@2.4.2))
+      vue-eslint-parser: 9.4.3(eslint@9.23.0(jiti@2.4.2))
       yoctocolors: 2.1.1
     transitivePeerDependencies:
       - '@testing-library/dom'
@@ -3951,7 +3964,7 @@ snapshots:
 
   eslint-import-resolver-custom-alias@1.3.2(eslint-plugin-import@2.31.0):
     dependencies:
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.28.0(eslint@9.23.0(jiti@2.4.2))(typescript@5.8.2))(eslint@9.23.0(jiti@2.4.2))
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.28.0(eslint@9.18.0(jiti@2.4.2))(typescript@5.8.2))(eslint@9.23.0(jiti@2.4.2))
       glob-parent: 6.0.2
       resolve: 1.22.10
 
@@ -3975,18 +3988,17 @@ snapshots:
       is-glob: 4.0.3
       stable-hash: 0.0.4
     optionalDependencies:
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.28.0(eslint@9.23.0(jiti@2.4.2))(typescript@5.8.2))(eslint@9.23.0(jiti@2.4.2))
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.28.0(eslint@9.18.0(jiti@2.4.2))(typescript@5.8.2))(eslint@9.23.0(jiti@2.4.2))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.28.0(eslint@9.23.0(jiti@2.4.2))(typescript@5.8.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0)(eslint@9.18.0(jiti@2.4.2)):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.28.0(eslint@9.18.0(jiti@2.4.2))(typescript@5.8.2))(eslint-import-resolver-node@0.3.9)(eslint@9.23.0(jiti@2.4.2)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
-      '@typescript-eslint/parser': 8.28.0(eslint@9.18.0(jiti@2.4.2))(typescript@5.8.2)
-      eslint: 9.18.0(jiti@2.4.2)
+      '@typescript-eslint/parser': 8.28.0(eslint@9.23.0(jiti@2.4.2))(typescript@5.8.2)
+      eslint: 9.23.0(jiti@2.4.2)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.7.0(eslint-plugin-import@2.31.0)(eslint@9.18.0(jiti@2.4.2))
     transitivePeerDependencies:
       - supports-color
 
@@ -4028,7 +4040,7 @@ snapshots:
       eslint: 9.18.0(jiti@2.4.2)
       eslint-compat-utils: 0.6.4(eslint@9.18.0(jiti@2.4.2))
 
-  eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.28.0(eslint@9.23.0(jiti@2.4.2))(typescript@5.8.2))(eslint@9.23.0(jiti@2.4.2)):
+  eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.28.0(eslint@9.18.0(jiti@2.4.2))(typescript@5.8.2))(eslint@9.23.0(jiti@2.4.2)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.8
@@ -4039,7 +4051,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.23.0(jiti@2.4.2)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.28.0(eslint@9.23.0(jiti@2.4.2))(typescript@5.8.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0)(eslint@9.18.0(jiti@2.4.2))
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.28.0(eslint@9.18.0(jiti@2.4.2))(typescript@5.8.2))(eslint-import-resolver-node@0.3.9)(eslint@9.23.0(jiti@2.4.2))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -4051,7 +4063,7 @@ snapshots:
       string.prototype.trimend: 1.0.9
       tsconfig-paths: 3.15.0
     optionalDependencies:
-      '@typescript-eslint/parser': 8.28.0(eslint@9.18.0(jiti@2.4.2))(typescript@5.8.2)
+      '@typescript-eslint/parser': 8.28.0(eslint@9.23.0(jiti@2.4.2))(typescript@5.8.2)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
@@ -4067,12 +4079,12 @@ snapshots:
     dependencies:
       eslint: 9.18.0(jiti@2.4.2)
 
-  eslint-plugin-jest@28.11.0(@typescript-eslint/eslint-plugin@8.28.0(@typescript-eslint/parser@8.28.0(eslint@9.23.0(jiti@2.4.2))(typescript@5.8.2))(eslint@9.18.0(jiti@2.4.2))(typescript@5.8.2))(eslint@9.18.0(jiti@2.4.2))(typescript@5.8.2):
+  eslint-plugin-jest@28.11.0(@typescript-eslint/eslint-plugin@8.28.0(@typescript-eslint/parser@8.28.0(eslint@9.18.0(jiti@2.4.2))(typescript@5.8.2))(eslint@9.18.0(jiti@2.4.2))(typescript@5.8.2))(eslint@9.18.0(jiti@2.4.2))(typescript@5.8.2):
     dependencies:
       '@typescript-eslint/utils': 8.28.0(eslint@9.18.0(jiti@2.4.2))(typescript@5.8.2)
       eslint: 9.18.0(jiti@2.4.2)
     optionalDependencies:
-      '@typescript-eslint/eslint-plugin': 8.28.0(@typescript-eslint/parser@8.28.0(eslint@9.23.0(jiti@2.4.2))(typescript@5.8.2))(eslint@9.23.0(jiti@2.4.2))(typescript@5.8.2)
+      '@typescript-eslint/eslint-plugin': 8.28.0(@typescript-eslint/parser@8.28.0(eslint@9.18.0(jiti@2.4.2))(typescript@5.8.2))(eslint@9.23.0(jiti@2.4.2))(typescript@5.8.2)
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -4533,7 +4545,7 @@ snapshots:
       postcss-scss: 4.0.9(postcss@8.5.3)
       postcss-selector-parser: 6.1.2
       postcss-styl: 0.12.3
-      vue-eslint-parser: 9.4.3(eslint@9.18.0(jiti@2.4.2))
+      vue-eslint-parser: 9.4.3(eslint@9.23.0(jiti@2.4.2))
     transitivePeerDependencies:
       - supports-color
 
@@ -5930,6 +5942,19 @@ snapshots:
     dependencies:
       debug: 4.4.0
       eslint: 9.18.0(jiti@2.4.2)
+      eslint-scope: 7.2.2
+      eslint-visitor-keys: 3.4.3
+      espree: 9.6.1
+      esquery: 1.6.0
+      lodash: 4.17.21
+      semver: 7.6.3
+    transitivePeerDependencies:
+      - supports-color
+
+  vue-eslint-parser@9.4.3(eslint@9.23.0(jiti@2.4.2)):
+    dependencies:
+      debug: 4.4.0
+      eslint: 9.23.0(jiti@2.4.2)
       eslint-scope: 7.2.2
       eslint-visitor-keys: 3.4.3
       espree: 9.6.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,10 +7,6 @@ settings:
 importers:
 
   .:
-    dependencies:
-      '@rollup/rollup-win32-ia32-msvc':
-        specifier: ^4.37.0
-        version: 4.37.0
     devDependencies:
       '@types/node':
         specifier: ^22.13.14
@@ -3196,7 +3192,8 @@ snapshots:
   '@rollup/rollup-win32-arm64-msvc@4.37.0':
     optional: true
 
-  '@rollup/rollup-win32-ia32-msvc@4.37.0': {}
+  '@rollup/rollup-win32-ia32-msvc@4.37.0':
+    optional: true
 
   '@rollup/rollup-win32-x64-msvc@4.37.0':
     optional: true

--- a/src/index.ts
+++ b/src/index.ts
@@ -164,6 +164,14 @@ export default class Tree<T, U = T> {
     root.add(this.counter++, value)
   }
 
+  /**
+   *  Adds an array of new nodes to the tree.
+   *
+   *  @param values - array holding the target values to insert.
+   *  @param traverser - callback mapping the target value to a node value to check for further traversal.
+   *  @param eq - callback checking if the target value is equal to a node value. If it's equal, it will cancel the process.
+   *  @param root - starting element to traverse through. By default, it starts at the tree root.
+   */
   addAll(values: T[], traverser: TreeComparator<T, T> = this.#comp as unknown as TreeComparator<T, T>, eq: TreeComparator<T> = this.#eq as unknown as TreeComparator<T, T>, root = this.root): void {
     for (const item of values) this.add(item, traverser, eq, root)
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -205,7 +205,7 @@ export default class Tree<T, U = T> {
    *  Checks if a specific value exists inside the tree.
    *
    *  @param value - target value.
-   *  @param comp - comparator callback to compare the node value with the target value with.
+   *  @param comp - comparator callback to compare the node value with the target value with for further traversal.
    *  @param traverser - callback to decide whether to traverse downwards to the children.
    *  @param root - starting element to traverse through. By default, it starts at the tree root.
    *  @returns `true`, if the tree has the value, otherwise `false`.
@@ -215,16 +215,14 @@ export default class Tree<T, U = T> {
     if (!root.isLeaf()) {
       for (const child of root.children) {
         if (comp(child, value)) return true
-        if (traverser(child, value)) {
-          return this.has(value, comp, traverser, child)
-        }
+        if (traverser(child, value)) return this.has(value, comp, traverser, child)
       }
     }
     return false
   }
 
   /**
-   *  Finds a node by its id. Ids are an internally incremened number.
+   *  Finds a node by its id. Ids are an internally incremented number.
    *
    * @param id - internal id of the targeted node.
    * @returns either the found node or `undefined`.
@@ -235,6 +233,26 @@ export default class Tree<T, U = T> {
         return node
       }
     }
+  }
+
+  /**
+   *  Finds a node by a given search value. It's particularly useful for getting an inner node to act as a sub-tree root for sub-tree operations.
+   *
+   *  @param value - target search value
+   *  @param comp - comparator callback to compare the node value with the target value with for further traversal.
+   *  @param eq - equality callback to compare the node value with the target to determine the correct node to find.
+   *  @param root - starting element to traverse through. By default, it starts at the tree root.
+   *  @returns either the desired `TreeNode` or `undefined`, if not found.
+   */
+  nodeByValue(value: U, comp: TreeComparator<T, U> = this.#comp, eq: TreeComparator<T, U> = this.#eq, root = this.root): TreeNode<T> | undefined {
+    if (eq(root, value)) return root
+    if (!root.isLeaf()) {
+      for (const child of root.children) {
+        if (eq(child, value)) return child
+        if (comp(child, value)) return this.nodeByValue(value, comp, eq, child)
+      }
+    }
+    return undefined
   }
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -194,9 +194,6 @@ export default class Tree<T, U = T> {
           return this.branch(targetValue, comp, eq, child, store)
         }
       }
-      // Edge case: Value not found
-      // In nested invalid values, we need to discard the rest of the branch as well. So it's easier to just return an empty array.
-      return []
     }
     return eq(root, targetValue) ? store : []
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -150,7 +150,12 @@ export default class Tree<T, U = T> {
    *  @param eq - callback checking if the target value is equal to a node value. If it's equal, it will cancel the process.
    *  @param root - starting element to traverse through. By default, it starts at the tree root.
    */
-  add(value: T, traverser: TreeComparator<T, T> = this.#comp as unknown as TreeComparator<T, T>, eq: TreeComparator<T, T> = this.#eq as unknown as TreeComparator<T, T>, root = this.root): void {
+  add(
+    value: T,
+    traverser: TreeComparator<T, T> = this.#comp as unknown as TreeComparator<T, T>,
+    eq: TreeComparator<T, T> = this.#eq as unknown as TreeComparator<T, T>,
+    root = this.root
+  ): void {
     if (eq(root, value)) return
     if (!root.isLeaf()) {
       for (const child of root.children) {
@@ -172,7 +177,12 @@ export default class Tree<T, U = T> {
    *  @param eq - callback checking if the target value is equal to a node value. If it's equal, it will cancel the process.
    *  @param root - starting element to traverse through. By default, it starts at the tree root.
    */
-  addAll(values: T[], traverser: TreeComparator<T, T> = this.#comp as unknown as TreeComparator<T, T>, eq: TreeComparator<T, T> = this.#eq as unknown as TreeComparator<T, T>, root = this.root): void {
+  addAll(
+    values: T[],
+    traverser: TreeComparator<T, T> = this.#comp as unknown as TreeComparator<T, T>,
+    eq: TreeComparator<T, T> = this.#eq as unknown as TreeComparator<T, T>,
+    root = this.root
+  ): void {
     for (const item of values) this.add(item, traverser, eq, root)
   }
 
@@ -186,7 +196,13 @@ export default class Tree<T, U = T> {
    *  the root element will be created.
    *  @returns the values of the branch leading towards the targeted value. If the value couldn't be found at all, it will return an empty array.
    */
-  branch(targetValue: U, comp: TreeComparator<T, U> = this.#comp, eq: TreeComparator<T, U> = this.#eq, root = this.root, store: T[] = [root.value]): T[] {
+  branch(
+    targetValue: U,
+    comp: TreeComparator<T, U> = this.#comp,
+    eq: TreeComparator<T, U> = this.#eq,
+    root = this.root,
+    store: T[] = [root.value]
+  ): T[] {
     if (!root.isLeaf()) {
       for (const child of root.children) {
         if (comp(child, targetValue)) {
@@ -278,7 +294,7 @@ export default class Tree<T, U = T> {
     }
   }
 
-  *[Symbol.iterator](): Iterator<TreeNode<T>> {
+  * [Symbol.iterator](): Iterator<TreeNode<T>> {
     const queue: TreeNode<T>[] = [this.root]
     while (queue.length > 0) {
       const currentNode = queue.shift()!

--- a/src/index.ts
+++ b/src/index.ts
@@ -133,7 +133,7 @@ export default class Tree<T, U = T> {
   private removeMeta(root: TreeNode<T>, child: TreeNode<T>, children: TreeNode<T>[]): void {
     children.splice(children.indexOf(child), 1)
     this.counter -= child.totalCount + 1
-    root.childCount -= child.totalCount
+    root.childCount--
 
     let parent: TreeNode<T> | undefined = root
     while (parent) {
@@ -241,7 +241,7 @@ export default class Tree<T, U = T> {
     if (comp(root, value)) {
       const parent = root.parent
       if (parent) {
-        this.removeMeta(root.parent, root, root.parent.children)
+        this.removeMeta(parent, root, parent.children)
       } else {
         this.root = new TreeNode(0, undefined as any)
         this.counter = 0

--- a/src/index.ts
+++ b/src/index.ts
@@ -150,7 +150,7 @@ export default class Tree<T, U = T> {
    *  @param eq - callback checking if the target value is equal to a node value. If it's equal, it will cancel the process.
    *  @param root - starting element to traverse through. By default, it starts at the tree root.
    */
-  add(value: T, traverser: TreeComparator<T, T> = this.#comp as unknown as TreeComparator<T, T>, eq: TreeComparator<T> = this.#eq as unknown as TreeComparator<T, T>, root = this.root): void {
+  add(value: T, traverser: TreeComparator<T, T> = this.#comp as unknown as TreeComparator<T, T>, eq: TreeComparator<T, T> = this.#eq as unknown as TreeComparator<T, T>, root = this.root): void {
     if (eq(root, value)) return
     if (!root.isLeaf()) {
       for (const child of root.children) {
@@ -172,7 +172,7 @@ export default class Tree<T, U = T> {
    *  @param eq - callback checking if the target value is equal to a node value. If it's equal, it will cancel the process.
    *  @param root - starting element to traverse through. By default, it starts at the tree root.
    */
-  addAll(values: T[], traverser: TreeComparator<T, T> = this.#comp as unknown as TreeComparator<T, T>, eq: TreeComparator<T> = this.#eq as unknown as TreeComparator<T, T>, root = this.root): void {
+  addAll(values: T[], traverser: TreeComparator<T, T> = this.#comp as unknown as TreeComparator<T, T>, eq: TreeComparator<T, T> = this.#eq as unknown as TreeComparator<T, T>, root = this.root): void {
     for (const item of values) this.add(item, traverser, eq, root)
   }
 

--- a/test/Tree.test.ts
+++ b/test/Tree.test.ts
@@ -263,5 +263,22 @@ describe('Tree', () => {
       expect(tree.has('/package.json')).toBe(true)
       expect(tree.has('/a/b/c')).toBe(false)
     })
+
+    it('can find a node by its value', () => {
+      for (let i = 0; i < 10; i++) tree.add(i)
+
+      expect(tree.nodeByValue(5)?.value).toEqual(5)
+      expect(tree.nodeByValue(-1)).toBeUndefined()
+      expect(tree.nodeByValue(11)).toBeUndefined()
+    })
+
+    it('can find a node by its value inside complex data', () => {
+      const tree = getComplexDataTree()
+
+      expect(tree.nodeByValue('/')?.value.path).toBe('/')
+      expect(tree.nodeByValue('/a/b')?.value.path).toBe('/a/b')
+      expect(tree.nodeByValue('')).toBeUndefined()
+      expect(tree.nodeByValue('/a/b/c')).toBeUndefined()
+    })
   })
 })

--- a/test/Tree.test.ts
+++ b/test/Tree.test.ts
@@ -2,17 +2,22 @@ import { describe, it, expect, beforeEach } from 'vitest'
 import Tree, { TreeNode, type AsyncTraverser } from '../src'
 
 interface TestPathMetadata {
-
-
   path: string
-
-
   dir: boolean
-
-
   fileCount: number
+}
 
 
+function getComplexDataTree(): Tree<TestPathMetadata, string> {
+  const tree = new Tree<TestPathMetadata, string>({ path: '/', dir: true, fileCount: 5 }, (n, v) => v.startsWith(n.value.path), (n, v) => v === n.value.path)
+
+  tree.addAll([
+    { path: '/package.json', dir: false, fileCount: 0 },
+    { path: '/a', dir: true, fileCount: 1 },
+    { path: '/a/package.json', dir: false, fileCount: 0 },
+    { path: '/a/b', dir: true, fileCount: 0 }
+  ], (n, v) => v.path.startsWith(n.value.path), (n, v) => v.path === n.value.path)
+  return tree
 }
 
 describe('Tree', () => {
@@ -181,6 +186,14 @@ describe('Tree', () => {
       expect(tree.root.value).toBeUndefined()
       expect(tree.counter).toBe(0)
     })
+
+    it('can remove complex data with primitive data', () => {
+      const tree = getComplexDataTree()
+
+      tree.remove('/package.json')
+      expect(tree.root.childCount).toBe(1)
+
+    })
   })
 
   describe('Branches', () => {
@@ -198,6 +211,18 @@ describe('Tree', () => {
 
       // Shouldn't retrieve invalid branches
       expect(pathTree.branch('foobar')).toEqual([])
+
+      // Deep invalid branch
+      expect(pathTree.branch('/a/foobar')).toEqual([])
+    })
+
+    it('can retrieve a branch of complex data from a primitive value', () => {
+      const tree = getComplexDataTree()
+
+      expect(tree.branch('/a/b').map((v) => v.path)).toEqual(['/', '/a', '/a/b'])
+      expect(tree.branch('/package.json').map((v) => v.path)).toEqual(['/', '/package.json'])
+      expect(tree.branch('/c')).toEqual([])
+      expect(tree.branch('/a/b/c')).toEqual([])
     })
   })
 
@@ -229,6 +254,14 @@ describe('Tree', () => {
       expect(tree.has(0)).toBe(true)
       expect(tree.has(-1)).toBe(false)
       expect(tree.has(2567834)).toBe(false)
+    })
+
+    it('can search for primitive data in complex data', () => {
+      const tree = getComplexDataTree()
+
+      expect(tree.has('/a/b')).toBe(true)
+      expect(tree.has('/package.json')).toBe(true)
+      expect(tree.has('/a/b/c')).toBe(false)
     })
   })
 })

--- a/test/Tree.test.ts
+++ b/test/Tree.test.ts
@@ -7,16 +7,23 @@ interface TestPathMetadata {
   fileCount: number
 }
 
-
 function getComplexDataTree(): Tree<TestPathMetadata, string> {
-  const tree = new Tree<TestPathMetadata, string>({ path: '/', dir: true, fileCount: 5 }, (n, v) => v.startsWith(n.value.path), (n, v) => v === n.value.path)
+  const tree = new Tree<TestPathMetadata, string>(
+    { path: '/', dir: true, fileCount: 5 },
+    (n, v) => v.startsWith(n.value.path),
+    (n, v) => v === n.value.path
+  )
 
-  tree.addAll([
-    { path: '/package.json', dir: false, fileCount: 0 },
-    { path: '/a', dir: true, fileCount: 1 },
-    { path: '/a/package.json', dir: false, fileCount: 0 },
-    { path: '/a/b', dir: true, fileCount: 0 }
-  ], (n, v) => v.path.startsWith(n.value.path), (n, v) => v.path === n.value.path)
+  tree.addAll(
+    [
+      { path: '/package.json', dir: false, fileCount: 0 },
+      { path: '/a', dir: true, fileCount: 1 },
+      { path: '/a/package.json', dir: false, fileCount: 0 },
+      { path: '/a/b', dir: true, fileCount: 0 }
+    ],
+    (n, v) => v.path.startsWith(n.value.path),
+    (n, v) => v.path === n.value.path
+  )
   return tree
 }
 
@@ -192,7 +199,6 @@ describe('Tree', () => {
 
       tree.remove('/package.json')
       expect(tree.root.childCount).toBe(1)
-
     })
   })
 
@@ -222,8 +228,8 @@ describe('Tree', () => {
     it('can retrieve a branch of complex data from a primitive value', () => {
       const tree = getComplexDataTree()
 
-      expect(tree.branch('/a/b').map((v) => v.path)).toEqual(['/', '/a', '/a/b'])
-      expect(tree.branch('/package.json').map((v) => v.path)).toEqual(['/', '/package.json'])
+      expect(tree.branch('/a/b').map(v => v.path)).toEqual(['/', '/a', '/a/b'])
+      expect(tree.branch('/package.json').map(v => v.path)).toEqual(['/', '/package.json'])
       expect(tree.branch('/c')).toEqual([])
       expect(tree.branch('/a/b/c')).toEqual([])
     })

--- a/test/Tree.test.ts
+++ b/test/Tree.test.ts
@@ -1,5 +1,19 @@
 import { describe, it, expect, beforeEach } from 'vitest'
-import Tree, { TreeNode, type Traverser, type AsyncTraverser } from '../src'
+import Tree, { TreeNode, type AsyncTraverser } from '../src'
+
+interface TestPathMetadata {
+
+
+  path: string
+
+
+  dir: boolean
+
+
+  fileCount: number
+
+
+}
 
 describe('Tree', () => {
   let tree: Tree<number>
@@ -89,6 +103,22 @@ describe('Tree', () => {
 
       expect(tree.root.childCount).toBe(1)
       expect(tree.counter).toBe(2)
+    })
+
+    it('should not add duplicate root value', () => {
+      tree.add(0)
+
+      expect(tree.root.childCount).toBe(0)
+      expect(tree.counter).toBe(1)
+    })
+
+    it('can add multiple values at once', () => {
+      const array: number[] = []
+      for (let i = 0; i < 100; i++) array.push(i)
+      tree.addAll(array)
+
+      let counter = 0
+      for (const node of tree) expect(node.value).toBe(counter++)
     })
   })
 

--- a/test/Tree.test.ts
+++ b/test/Tree.test.ts
@@ -209,6 +209,9 @@ describe('Tree', () => {
       expect(pathTree.branch('/a/c/e')).toEqual(['/', '/a', '/a/c', '/a/c/e'])
       expect(pathTree.branch('/b/d/f')).toEqual(['/', '/b', '/b/d', '/b/d/f'])
 
+      // Should stop after reaching target node, even if its not a leaf
+      expect(pathTree.branch('/a/c')).toEqual(['/', '/a', '/a/c'])
+
       // Shouldn't retrieve invalid branches
       expect(pathTree.branch('foobar')).toEqual([])
 


### PR DESCRIPTION
This update takes care of how to handle complex data. I somehow skipped over this when making this package, but now it's here!

All new things should be migrated seamlessly, but there are a few additions to that enhances the use of `mini-tree`:

- `addAll` to parse an array of values into the tree
- `nodeByValue` to fetch a node with a specific target value from the tree for use in sub-tree operations.

I've also added a lot of new test cases to further solidify the correctness of find values. There were a few bugs of edge cases that I missed.